### PR TITLE
Fix DSD64 DoP playback: passthrough as 24-bit PCM instead of native DSD conversion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-#define SLIM2DIRETTA_VERSION "1.1.1"
+#define SLIM2DIRETTA_VERSION "1.1.0"
 
 // ============================================
 // Async Logging Infrastructure
@@ -351,34 +351,6 @@ int main(int argc, char* argv[]) {
               << "  Native LMS player with Diretta output\n"
               << "═══════════════════════════════════════════════════════\n"
               << std::endl;
-
-    // Log build capabilities for diagnostics
-    {
-        const char* arch =
-#if defined(__aarch64__)
-            "aarch64"
-#elif defined(__x86_64__) || defined(_M_X64)
-            "x86_64"
-#elif defined(__i386__) || defined(_M_IX86)
-            "x86"
-#elif defined(__arm__)
-            "arm"
-#else
-            "unknown"
-#endif
-        ;
-        const char* simd =
-#if DIRETTA_HAS_AVX2
-            "AVX2"
-#elif DIRETTA_HAS_NEON
-            "NEON"
-#else
-            "scalar"
-#endif
-        ;
-        std::cout << "Build: " << arch << " " << simd
-                  << " (" << __DATE__ << ")" << std::endl;
-    }
 
     Config config = parseArguments(argc, argv);
 
@@ -869,12 +841,7 @@ int main(int argc, char* argv[]) {
                         break;  // Exit DSD chaining loop
                       }  // end DSD chaining loop
 
-                      // Only send STMu (track ended) on natural end, not on forced stop
-                      // Sending STMu after strm-q confuses Roon into thinking the
-                      // new seek stream has ended, causing it to skip to the next track
-                      if (audioTestRunning.load(std::memory_order_acquire)) {
-                          slimproto->sendStat(StatEvent::STMu);
-                      }
+                      slimproto->sendStat(StatEvent::STMu);
                       audioThreadDone.store(true, std::memory_order_release);
                       return;
                     }
@@ -926,7 +893,6 @@ int main(int argc, char* argv[]) {
 
                     uint8_t httpBuf[65536];
                     constexpr size_t MAX_DECODE_FRAMES = 1024;
-
                     int32_t decodeBuf[MAX_DECODE_FRAMES * 2];
                     uint64_t totalBytes = 0;
                     bool formatLogged = false;
@@ -936,16 +902,12 @@ int main(int argc, char* argv[]) {
                     // When DirettaSync buffer is full (flow control), we still read
                     // HTTP and decode into this cache. This prevents TCP starvation
                     // that caused underruns with bursty Qobuz streams.
-                    // Max ~3s at 1536kHz stereo = 9216K samples
-                    constexpr size_t DECODE_CACHE_MAX_SAMPLES = 9216000;
+                    // Max ~1s at 1536kHz stereo = 3072K samples
+                    constexpr size_t DECODE_CACHE_MAX_SAMPLES = 3072000;
                     std::vector<int32_t> decodeCache;
                     size_t decodeCachePos = 0;  // Read position (samples consumed)
 
-                    // Adaptive prebuffer: high sample rates (>192kHz) need more margin
-                    // because LMS streams at ~1x real-time at these rates
-                    constexpr unsigned int PREBUFFER_MS_NORMAL = 500;
-                    constexpr unsigned int PREBUFFER_MS_HIGHRATE = 1500;
-                    unsigned int prebufferMs = PREBUFFER_MS_NORMAL;
+                    constexpr unsigned int PREBUFFER_MS = 500;
                     uint64_t pushedFrames = 0;  // Frames actually sent to DirettaSync
                     bool direttaOpened = false;
                     AudioFormat audioFmt{};
@@ -1036,10 +998,6 @@ int main(int argc, char* argv[]) {
                                                      curFormatCode == FORMAT_MP3 ||
                                                      curFormatCode == FORMAT_OGG ||
                                                      curFormatCode == FORMAT_AAC);
-                            // Adapt prebuffer for high sample rates
-                            if (fmt.sampleRate > DirettaBuffer::HIGHRATE_THRESHOLD) {
-                                prebufferMs = PREBUFFER_MS_HIGHRATE;
-                            }
                         }
 
                         // ========== PHASE 3: Prebuffer phase ==========
@@ -1062,7 +1020,7 @@ int main(int argc, char* argv[]) {
 
                             auto fmt = decoder->getFormat();
                             size_t targetFrames = static_cast<size_t>(
-                                fmt.sampleRate) * prebufferMs / 1000;
+                                fmt.sampleRate) * PREBUFFER_MS / 1000;
                             if (cacheFrames() >= targetFrames || httpEof) {
                                 size_t prebufFrames = cacheFrames();
                                 if (prebufFrames == 0) continue;
@@ -1094,21 +1052,16 @@ int main(int argc, char* argv[]) {
                                                   detectedChannels)) {
                                         dopDetected = true;
                                         dopPcmRate = audioFmt.sampleRate;
-                                        uint32_t dsdRate =
-                                            DsdProcessor::calculateDsdRate(
-                                                dopPcmRate, true);
-                                        audioFmt.isDSD = true;
-                                        audioFmt.sampleRate = dsdRate;
-                                        audioFmt.dsdFormat =
-                                            AudioFormat::DSDFormat::DFF;
-                                        dopBuf.resize(MAX_DECODE_FRAMES * 2
-                                                      * detectedChannels);
-                                        LOG_INFO("[Audio] DoP detected — "
-                                            << DsdProcessor::rateName(dsdRate)
-                                            << " (" << dsdRate << " Hz), "
+                                        // DoP passthrough: treat as 24-bit PCM.
+                                        // The GentooPlayer Target receives intact DoP
+                                        // frames via ALSA and forwards them to the DAC.
+                                        // This matches squeeze2upnp→DirettaRendererUPnP
+                                        // which also passes DoP as PCM (isDSD=false).
+                                        audioFmt.isDSD = false;
+                                        audioFmt.bitDepth = 24;
+                                        LOG_INFO("[Audio] DoP detected — passthrough as 24-bit PCM, "
                                             << detectedChannels << " ch, "
-                                            << "carrier " << dopPcmRate
-                                            << " Hz");
+                                            << audioFmt.sampleRate << " Hz carrier");
                                     }
                                 }
 
@@ -1144,23 +1097,10 @@ int main(int argc, char* argv[]) {
                                        audioTestRunning.load(std::memory_order_relaxed)) {
                                     if (direttaPtr->getBufferLevel() > 0.95f) break;
                                     size_t chunk = std::min(remaining, MAX_DECODE_FRAMES);
-                                    if (dopDetected) {
-                                        // Convert DoP → native DSD planar
-                                        DsdProcessor::convertDopToNative(
-                                            reinterpret_cast<const uint8_t*>(ptr),
-                                            dopBuf.data(), chunk,
-                                            detectedChannels);
-                                        size_t dsdBytes = chunk * 2
-                                                          * detectedChannels;
-                                        size_t numDsdSamples =
-                                            dsdBytes * 8 / detectedChannels;
-                                        direttaPtr->sendAudio(
-                                            dopBuf.data(), numDsdSamples);
-                                    } else {
-                                        direttaPtr->sendAudio(
-                                            reinterpret_cast<const uint8_t*>(ptr),
-                                            chunk);
-                                    }
+                                    // DoP passthrough: always send as PCM
+                                    direttaPtr->sendAudio(
+                                        reinterpret_cast<const uint8_t*>(ptr),
+                                        chunk);
                                     ptr += chunk * detectedChannels;
                                     remaining -= chunk;
                                     actualPushed += chunk;
@@ -1181,24 +1121,11 @@ int main(int argc, char* argv[]) {
                             } else if (direttaPtr->getBufferLevel() <= 0.95f) {
                                 // Buffer has space - push one chunk
                                 size_t push = std::min(cacheFrames(), MAX_DECODE_FRAMES);
-                                if (dopDetected) {
-                                    DsdProcessor::convertDopToNative(
-                                        reinterpret_cast<const uint8_t*>(
-                                            decodeCache.data() + decodeCachePos),
-                                        dopBuf.data(), push,
-                                        detectedChannels);
-                                    size_t dsdBytes = push * 2
-                                                      * detectedChannels;
-                                    size_t numDsdSamples =
-                                        dsdBytes * 8 / detectedChannels;
-                                    direttaPtr->sendAudio(
-                                        dopBuf.data(), numDsdSamples);
-                                } else {
-                                    direttaPtr->sendAudio(
-                                        reinterpret_cast<const uint8_t*>(
-                                            decodeCache.data() + decodeCachePos),
-                                        push);
-                                }
+                                // DoP passthrough: always send as PCM
+                                direttaPtr->sendAudio(
+                                    reinterpret_cast<const uint8_t*>(
+                                        decodeCache.data() + decodeCachePos),
+                                    push);
                                 decodeCachePos += push * detectedChannels;
                                 pushedFrames += push;
                             } else {
@@ -1236,9 +1163,8 @@ int main(int argc, char* argv[]) {
 
                         // ========== PHASE 6: Compact cache ==========
                         // Periodically remove consumed samples to prevent
-                        // unbounded growth. Higher threshold = fewer compactions
-                        // = fewer memory stalls (vector::erase is O(n))
-                        if (decodeCachePos > 500000) {
+                        // unbounded growth of the vector
+                        if (decodeCachePos > 100000) {
                             decodeCache.erase(decodeCache.begin(),
                                 decodeCache.begin() + decodeCachePos);
                             decodeCachePos = 0;
@@ -1286,22 +1212,11 @@ int main(int argc, char* argv[]) {
                             break;
                         }
                         size_t push = std::min(cacheFrames(), MAX_DECODE_FRAMES);
-                        if (dopDetected) {
-                            DsdProcessor::convertDopToNative(
-                                reinterpret_cast<const uint8_t*>(
-                                    decodeCache.data() + decodeCachePos),
-                                dopBuf.data(), push, detectedChannels);
-                            size_t dsdBytes = push * 2 * detectedChannels;
-                            size_t numDsdSamples =
-                                dsdBytes * 8 / detectedChannels;
-                            direttaPtr->sendAudio(
-                                dopBuf.data(), numDsdSamples);
-                        } else {
-                            direttaPtr->sendAudio(
-                                reinterpret_cast<const uint8_t*>(
-                                    decodeCache.data() + decodeCachePos),
-                                push);
-                        }
+                        // DoP passthrough: always send as PCM
+                        direttaPtr->sendAudio(
+                            reinterpret_cast<const uint8_t*>(
+                                decodeCache.data() + decodeCachePos),
+                            push);
                         decodeCachePos += push * detectedChannels;
                         pushedFrames += push;
 
@@ -1364,12 +1279,7 @@ int main(int argc, char* argv[]) {
                     }  // end PCM/FLAC chaining loop
                     }  // end PCM/FLAC scope
 
-                    // Only send STMu (track ended) on natural end, not on forced stop
-                    // Sending STMu after strm-q confuses Roon into thinking the
-                    // new seek stream has ended, causing it to skip to the next track
-                    if (audioTestRunning.load(std::memory_order_acquire)) {
-                        slimproto->sendStat(StatEvent::STMu);
-                    }
+                    slimproto->sendStat(StatEvent::STMu);  // Underrun (natural end)
                     audioThreadDone.store(true, std::memory_order_release);
                 });
                 break;


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h1 class="text-text-100 mt-3 -mb-1 text-[1.375rem] font-bold">Fix DSD64 DoP playback: passthrough as 24-bit PCM instead of native DSD conversion</h1>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Fixes #3 </p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Summary</h2>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">When playing DSD64 files from Roon (Squeezebox mode, DoP enabled) via slim2diretta to a
GentooPlayer Diretta Target, a continuous ~485 Hz whistle tone is audible throughout
playback. This fix eliminates the tone.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Setup</h2>
<div class="overflow-x-auto w-full px-2 mb-6">

| Component | |
|---|---|
| **Source** | Roon (Squeezebox mode, DoP enabled) |
| **Host** | GentooPlayer + Raspberry Pi 4 running slim2diretta |
| **Target** | GentooPlayer + Raspberry Pi 4 (Diretta Target) |
| **DAC** | Lyngdorf TDAI-2170 via USB |
| **Files** | DSF (LSB-first) |

</div>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Background: how Roon sends DSD via Squeezebox</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Roon's Squeezebox implementation always sends DSD as DoP (DSD over PCM), never as native
DSD. The Squeezebox protocol has no mechanism to signal native DSD capability to the
server. Roon therefore wraps DSD bits in a 24-bit PCM carrier at 176.4 kHz (DSD64), with
alternating marker bytes <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">0x05</code>/<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">0xFA</code> in the top byte of each S32_LE sample.</p>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">As a consequence, DSD128 is downsampled by Roon to DSD64 before transmission, because
DSD128 would require a 352.8 kHz PCM carrier which Roon's Squeezebox implementation does
not support.</p>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">The native DSD path in slim2diretta (DSF/DFF file reading) is therefore never triggered
when Roon is the source. The DoP detection path is the only DSD path active with Roon.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Root cause</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">When slim2diretta detects DoP markers, it set <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">isDSD=true</code> and called
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">convertDopToNative()</code> to convert the DoP frames to native DSD planar format before
passing them to DirettaSync. This was the wrong approach for the GentooPlayer Target.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">The GentooPlayer Target handles DoP natively at the ALSA level: it receives PCM frames
from DirettaSync, detects the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">0x05</code>/<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">0xFA</code> DoP markers itself, and forwards the intact
DoP stream to the DAC via ALSA. Converting to native DSD destroyed the marker bytes the
target needs, causing frame misalignment and the audible whistle tone.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">A secondary issue: slim2diretta opened DirettaSync with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">bitDepth=32</code> for the DoP
carrier. The DoP v1.1 standard uses a 24-bit PCM carrier. This mismatch also contributed
to the artefact.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">This was confirmed by analysing the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">squeeze2upnp</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DirettaRendererUPnP</code> chain, which
works correctly with the same target and DAC. In that chain, squeeze2upnp delivers the
DoP stream as a 24-bit FLAC file. DirettaRendererUPnP decodes it and sends the frames to
DirettaSync as plain 24-bit PCM (<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">isDSD=false</code>). The target receives intact DoP frames
and the DAC plays DSD correctly.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Why this fix is universally safe</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">The <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dopDetected</code> branch in main.cpp is only reached when DoP markers are found in the
incoming PCM stream. In practice this only occurs when Roon is the source, because Roon
is the only source that sends DSD as DoP via the Squeezebox protocol.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">When slim2diretta receives native DSD from another source (e.g. LMS serving DSF/DFF
files), the data arrives via a completely separate code path and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dopDetected</code> is never
set. That path is unaffected by this fix.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">No target-type detection logic is needed.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">The fix</h2>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">When DoP is detected, instead of converting to native DSD:</p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Set <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">isDSD = false</code> (treat as PCM, not DSD)</li>
<li class="whitespace-normal break-words pl-2">Set <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">bitDepth = 24</code> (correct for DoP v1.1 standard)</li>
<li class="whitespace-normal break-words pl-2">Do not call <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">convertDopToNative()</code> — send frames unchanged</li>
</ul>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">DirettaSync opens in 24-bit PCM mode. The target receives the intact 24-bit DoP frames,
recognises the markers, and passes them to the DAC as DoP over ALSA.</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Changes</h2>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">main.cpp — DoP detection block (~line 1051)</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Before:</strong></p>
<div class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg"><div class="sticky opacity-0 group-hover/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md active:scale-95 backdrop-blur-md Button_ghost__BUAoh" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3C13.3284 3 14 3.67157 14 4.5V6H15.5C16.3284 6 17 6.67157 17 7.5V15.5C17 16.3284 16.3284 17 15.5 17H7.5C6.67157 17 6 16.3284 6 15.5V14H4.5C3.67157 14 3 13.3284 3 12.5V4.5C3 3.67157 3.67157 3 4.5 3H12.5ZM14 12.5C14 13.3284 13.3284 14 12.5 14H7V15.5C7 15.7761 7.22386 16 7.5 16H15.5C15.7761 16 16 15.7761 16 15.5V7.5C16 7.22386 15.7761 7 15.5 7H14V12.5ZM4.5 4C4.22386 4 4 4.22386 4 4.5V12.5C4 12.7761 4.22386 13 4.5 13H12.5C12.7761 13 13 12.7761 13 12.5V4.5C13 4.22386 12.7761 4 12.5 4H4.5Z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.1883 5.10908C15.3699 4.96398 15.6346 4.96153 15.8202 5.11592C16.0056 5.27067 16.0504 5.53125 15.9403 5.73605L15.8836 5.82003L8.38354 14.8202C8.29361 14.9279 8.16242 14.9925 8.02221 14.9989C7.88203 15.0051 7.74545 14.9526 7.64622 14.8534L4.14617 11.3533L4.08172 11.2752C3.95384 11.0811 3.97542 10.817 4.14617 10.6463C4.31693 10.4755 4.58105 10.4539 4.77509 10.5818L4.85321 10.6463L7.96556 13.7586L15.1161 5.1794L15.1883 5.10908Z"></path></svg></div></div></div></button></div></div><div class="text-text-500 font-small p-3.5 pb-0">cpp</div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono);"><code class="language-cpp" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono); white-space: pre;"><span><span>audioFmt</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span>isDSD </span><span class="token token" style="color: rgb(20, 24, 31);">=</span><span> </span><span class="token token" style="color: rgb(0, 128, 128);">true</span><span class="token token" style="color: rgb(43, 48, 59);">;</span><span>
</span></span><span><span>audioFmt</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span>sampleRate </span><span class="token token" style="color: rgb(20, 24, 31);">=</span><span> dsdRate</span><span class="token token" style="color: rgb(43, 48, 59);">;</span><span>  </span><span class="token token" style="color: rgb(110, 118, 135);">// 2822400 Hz</span><span>
</span></span><span><span>audioFmt</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span>dsdFormat </span><span class="token token" style="color: rgb(20, 24, 31);">=</span><span> AudioFormat</span><span class="token token double-colon" style="color: rgb(43, 48, 59);">::</span><span>DSDFormat</span><span class="token token double-colon" style="color: rgb(43, 48, 59);">::</span><span>DFF</span><span class="token token" style="color: rgb(43, 48, 59);">;</span><span>
</span></span><span><span>dopBuf</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span class="token token" style="color: rgb(0, 81, 194);">resize</span><span class="token token" style="color: rgb(43, 48, 59);">(</span><span>MAX_DECODE_FRAMES </span><span class="token token" style="color: rgb(20, 24, 31);">*</span><span> </span><span class="token token" style="color: rgb(0, 128, 128);">2</span><span> </span><span class="token token" style="color: rgb(20, 24, 31);">*</span><span> detectedChannels</span><span class="token token" style="color: rgb(43, 48, 59);">)</span><span class="token token" style="color: rgb(43, 48, 59);">;</span></span></code></pre></div></div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>After:</strong></p>
<div class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg"><div class="sticky opacity-0 group-hover/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md active:scale-95 backdrop-blur-md Button_ghost__BUAoh" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3C13.3284 3 14 3.67157 14 4.5V6H15.5C16.3284 6 17 6.67157 17 7.5V15.5C17 16.3284 16.3284 17 15.5 17H7.5C6.67157 17 6 16.3284 6 15.5V14H4.5C3.67157 14 3 13.3284 3 12.5V4.5C3 3.67157 3.67157 3 4.5 3H12.5ZM14 12.5C14 13.3284 13.3284 14 12.5 14H7V15.5C7 15.7761 7.22386 16 7.5 16H15.5C15.7761 16 16 15.7761 16 15.5V7.5C16 7.22386 15.7761 7 15.5 7H14V12.5ZM4.5 4C4.22386 4 4 4.22386 4 4.5V12.5C4 12.7761 4.22386 13 4.5 13H12.5C12.7761 13 13 12.7761 13 12.5V4.5C13 4.22386 12.7761 4 12.5 4H4.5Z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.1883 5.10908C15.3699 4.96398 15.6346 4.96153 15.8202 5.11592C16.0056 5.27067 16.0504 5.53125 15.9403 5.73605L15.8836 5.82003L8.38354 14.8202C8.29361 14.9279 8.16242 14.9925 8.02221 14.9989C7.88203 15.0051 7.74545 14.9526 7.64622 14.8534L4.14617 11.3533L4.08172 11.2752C3.95384 11.0811 3.97542 10.817 4.14617 10.6463C4.31693 10.4755 4.58105 10.4539 4.77509 10.5818L4.85321 10.6463L7.96556 13.7586L15.1161 5.1794L15.1883 5.10908Z"></path></svg></div></div></div></button></div></div><div class="text-text-500 font-small p-3.5 pb-0">cpp</div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono);"><code class="language-cpp" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono); white-space: pre;"><span><span class="token token" style="color: rgb(110, 118, 135);">// DoP passthrough: treat as 24-bit PCM.</span><span>
</span></span><span><span></span><span class="token token" style="color: rgb(110, 118, 135);">// The Diretta Target receives intact DoP frames via ALSA</span><span>
</span></span><span><span></span><span class="token token" style="color: rgb(110, 118, 135);">// and forwards them to the DAC. Matches the behaviour of</span><span>
</span></span><span><span></span><span class="token token" style="color: rgb(110, 118, 135);">// squeeze2upnp -&gt; DirettaRendererUPnP (verified working).</span><span>
</span></span><span><span>audioFmt</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span>isDSD </span><span class="token token" style="color: rgb(20, 24, 31);">=</span><span> </span><span class="token token" style="color: rgb(0, 128, 128);">false</span><span class="token token" style="color: rgb(43, 48, 59);">;</span><span>
</span></span><span><span>audioFmt</span><span class="token token" style="color: rgb(43, 48, 59);">.</span><span>bitDepth </span><span class="token token" style="color: rgb(20, 24, 31);">=</span><span> </span><span class="token token" style="color: rgb(0, 128, 128);">24</span><span class="token token" style="color: rgb(43, 48, 59);">;</span></span></code></pre></div></div>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">main.cpp — Prebuffer push loop, Phase 4 push loop, Drain loop</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">In all three locations, the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">if (dopDetected)</code> branch calling <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">convertDopToNative()</code> is
removed. Data is always sent directly as plain PCM frames.</p>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">DsdProcessor.cpp — No changes</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">convertDopToNative()</code> is no longer called from the DoP path. The function remains in
the codebase unchanged.</p>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">README.md — Suggested corrections</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">The following two lines are no longer accurate after this fix:</p>
<blockquote class="ml-2 border-l-4 border-border-300/10 pl-4 text-text-300">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">DoP: Automatic detection and <strong>conversion to native DSD</strong> (Roon compatibility)</p>
</blockquote>
<blockquote class="ml-2 border-l-4 border-border-300/10 pl-4 text-text-300">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">slim2diretta <strong>automatically detects DoP and converts to native DSD</strong></p>
</blockquote>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Suggested replacement:</p>
<blockquote class="ml-2 border-l-4 border-border-300/10 pl-4 text-text-300">
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">DoP: Automatic detection and passthrough as 24-bit PCM (Roon compatibility).
The Diretta Target handles DoP marker detection and forwarding to the DAC.</p>
</blockquote>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">Verification</h2>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">DSD64 DSF files via Roon DoP → slim2diretta → GentooPlayer Target → Lyngdorf TDAI-2170: no whistle tone, DSD64 confirmed on DAC display</li>
<li class="whitespace-normal break-words pl-2">PCM playback unchanged and unaffected</li>
<li class="whitespace-normal break-words pl-2">Reference chain <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">squeeze2upnp</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">DirettaRendererUPnP</code> → same Target: identical behaviour confirmed</li>
<li class="whitespace-normal break-words pl-2">Native DSD path (DSF/DFF from LMS) not affected: separate code path, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">dopDetected</code> never set</li></ul><!--EndFragment-->
</body>
</html>