### PR TITLE
Add support for Clang+LTO and verbose logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(DEFINED LLVM)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
 endif()
 
 # Architecture-specific SIMD flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
+
+# Compiler detection and toolchain settings must be specified before the project() command.
+if(DEFINED LLVM)
+    # Explicitly set both compilers to maintain toolchain parity and prevent LTO mismatches.
+    set(CMAKE_C_COMPILER "clang")
+    set(CMAKE_CXX_COMPILER "clang++")
+endif()
+
 project(slim2diretta VERSION 1.2.5)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -533,6 +541,10 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O2")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(DEFINED LLVM)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
+endif()
 
 # Architecture-specific SIMD flags
 # TARGET_MARCH allows cross-compilation: cmake -DTARGET_MARCH=v3 ..

--- a/install.sh
+++ b/install.sh
@@ -291,11 +291,19 @@ build_slim2diretta() {
 
     # Configure with CMake
     print_info "Configuring with CMake..."
-    cmake ..
+    CMAKE_ARGS=()
+    if [ -n "$LLVM" ]; then
+        CMAKE_ARGS+=("-DLLVM=$LLVM")
+    fi
+    cmake "${CMAKE_ARGS[@]}" ..
 
     # Build
     print_info "Building slim2diretta..."
-    make -j$(nproc)
+    MAKE_ARGS=("-j$(nproc)")
+    if [[ -n "$VERBOSE" || -n "$V" ]]; then
+        MAKE_ARGS+=("VERBOSE=1")
+    fi
+    make "${MAKE_ARGS[@]}"
 
     # Verify build
     if [ -f "slim2diretta" ]; then


### PR DESCRIPTION
## Description

This PR introduces support for the **Clang** compiler and adds a **verbose build logging** mechanism.

### Key Changes:
* **Clang + LTO Support:** Added support for building with Clang. From my testing, the Clang + LTO (Link Time Optimization) toolchain provides preferable performance and sound characteristics (e.g., `env LLVM=1 ./install.sh -b`).
* **Verbose Logging:** Added support for the `VERBOSE` or `V` environment variables. This allows developers to see the detailed build output for easier debugging and observation (e.g., `env VERBOSE=1 ./install.sh -b`).

### Motivation:
I personally find the Clang + LTO build to be superior for audio-related performance. I wanted to make this available as an option for others while also making the build process more transparent through verbose logs.

I would appreciate it if you could review these changes and let me know if this functionality aligns with the project's goals.

Thank you!