### PR TITLE
Set cpu affinity for main thread if configured

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -503,6 +503,17 @@ int main(int argc, char* argv[]) {
     }
     std::cout << std::endl;
 
+    // Pin Main thread to cpuOther core if configured
+    if (config.cpuOther >= 0) {
+        cpu_set_t cpuset;
+        CPU_ZERO(&cpuset);
+        CPU_SET(config.cpuOther, &cpuset);
+        if (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset) == 0) {
+            std::cout << "[Main] Thread pinned to CPU core "
+                      << config.cpuOther << std::endl;
+        }
+    }
+
     // Create and enable DirettaSync
     auto diretta = std::make_unique<DirettaSync>();
     diretta->setTargetIndex(config.direttaTarget - 1);  // CLI 1-indexed → API 0-indexed


### PR DESCRIPTION
## Summary
After configuring `--cpu-audio` and `--cpu-other`, I observed that one specific thread was still being managed by the OS scheduler instead of being pinned to the designated cores. 

Using `pstree`, I confirmed that this unpinned thread is the **main thread**. This PR addresses the issue by ensuring the main thread follows the CPU affinity settings.

## Changes
- Implemented the CPU pinning logic for the main thread.
- The logic is executed immediately after the configuration is printed. 

Please let me know if this is the preferred location for this logic.

Thank you!